### PR TITLE
Feature/2.0 no search csrf

### DIFF
--- a/Action/ListAction.php
+++ b/Action/ListAction.php
@@ -158,7 +158,7 @@ class ListAction extends RouteAction
         $form = null;
         if ($enabled) {
             $formBuilder = $this->get('form.factory')
-                ->createNamedBuilder('form', $this->getOption('advanced_search_parameter'))
+                ->createNamedBuilder('form', $this->getOption('advanced_search_parameter'), null, array('csrf_protection' => false))
             ;
             $filters = $this->getAdvancedSearchFilters($fields);
             foreach ($filters as $fieldName => $filter) {


### PR DESCRIPTION
CSRF protection is designed to stop people taking unintentional actions when submitting a form. A search is not an action - it's perfectly valid & useful to link to some search results, so it doesn't need CSRF protection. In GBK, I would like to put links on edit pages in one category to search results of another.

In general, any GET request shouldn't need CSRF protection - GET requests should only fetch data, POST requests should always be used to take an action. CSRF is used to dupe users into unintentionally taking an action.
