### PR TITLE
[WIP; do not merge] Remove deprecated calls for Symfony <=2.8

### DIFF
--- a/Action/ListAction.php
+++ b/Action/ListAction.php
@@ -16,6 +16,7 @@ use Pablodip\ModuleBundle\OptionBag;
 use Pagerfanta\Pagerfanta;
 use Pagerfanta\Exception\NotValidCurrentPageException;
 use Pablodip\AdminModuleBundle\Filter\FilterInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 
 /**
  * ListAction.
@@ -158,12 +159,12 @@ class ListAction extends RouteAction
         $form = null;
         if ($enabled) {
             $formBuilder = $this->get('form.factory')
-                ->createNamedBuilder($this->getOption('advanced_search_parameter'), 'form', null, array('csrf_protection' => false))
+                ->createNamedBuilder($this->getOption('advanced_search_parameter'), FormType::class, null, array('csrf_protection' => false))
             ;
             $filters = $this->getAdvancedSearchFilters($fields);
             foreach ($filters as $fieldName => $filter) {
                 $fieldData = $fields->get($fieldName);
-                $filterFormBuilder = $this->get('form.factory')->createNamedBuilder($fieldName, 'form', null, array('label' => $fieldData->getLabel()));
+                $filterFormBuilder = $this->get('form.factory')->createNamedBuilder($fieldName, FormType::class, null, array('label' => $fieldData->getLabel()));
                 $filter->buildForm($filterFormBuilder);
                 $formBuilder->add($filterFormBuilder);
             }

--- a/Field/Guesser/ValidatorFieldGuesser.php
+++ b/Field/Guesser/ValidatorFieldGuesser.php
@@ -46,8 +46,8 @@ class ValidatorFieldGuesser implements FieldGuesserInterface
         $classMetadata = $this->metadataFactory->getMetadataFor($class);
         // normal and camelized for getters
         foreach (array($fieldName, Container::camelize($fieldName)) as $name) {
-            if ($classMetadata->hasMemberMetadatas($name)) {
-                foreach ($classMetadata->getMemberMetadatas($name) as $memberMetadata) {
+            if ($classMetadata->hasPropertyMetadata($name)) {
+                foreach ($classMetadata->getPropertyMetadata($name) as $memberMetadata) {
                     foreach ($memberMetadata->getConstraints() as $constraint) {
                         $options = array_merge($options, $this->guessOptionsForConstraint($constraint));
                     }

--- a/Filter/BooleanFilter.php
+++ b/Filter/BooleanFilter.php
@@ -34,9 +34,6 @@ class BooleanFilter extends BaseFilter
                 'No' => 'no',
             ),
             'choices_as_values' => true,
-            'choice_value' => function ($choice) {
-                return $choice;
-            },
         ));
     }
 

--- a/Filter/BooleanFilter.php
+++ b/Filter/BooleanFilter.php
@@ -26,11 +26,17 @@ class BooleanFilter extends BaseFilter
      */
     public function buildForm(FormBuilder $formBuilder)
     {
-        $formBuilder->add('value', 'choice', array('choices' => array(
-            'yes_or_no' => 'Yes or No',
-            'yes'       => 'Yes',
-            'no'        => 'No',
-        )));
+        $formBuilder->add('value', 'choice', array(
+            'choices' => array(
+                'Yes or No' => 'yes_or_no',
+                'Yes' => 'yes',
+                'No' => 'no',
+            ),
+            'choices_as_values' => true,
+            'choice_value' => function ($choice) {
+                return $choice;
+            },
+        ));
     }
 
     /**

--- a/Filter/BooleanFilter.php
+++ b/Filter/BooleanFilter.php
@@ -11,6 +11,7 @@
 
 namespace Pablodip\AdminModuleBundle\Filter;
 
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilder;
 use Molino\QueryInterface;
 
@@ -26,7 +27,7 @@ class BooleanFilter extends BaseFilter
      */
     public function buildForm(FormBuilder $formBuilder)
     {
-        $formBuilder->add('value', 'choice', array(
+        $formBuilder->add('value', ChoiceType::class, array(
             'choices' => array(
                 'Yes or No' => 'yes_or_no',
                 'Yes' => 'yes',

--- a/Filter/IntegerFilter.php
+++ b/Filter/IntegerFilter.php
@@ -2,6 +2,8 @@
 
 namespace Pablodip\AdminModuleBundle\Filter;
 
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilder;
 use Molino\QueryInterface;
 
@@ -15,7 +17,7 @@ class IntegerFilter extends BaseFilter
      */
     public function buildForm(FormBuilder $formBuilder)
     {
-        $formBuilder->add('type', 'choice', array(
+        $formBuilder->add('type', ChoiceType::class, array(
             'choices' => array(
                 '=' => 'equals',
                 '>' => 'greater_than',
@@ -28,7 +30,7 @@ class IntegerFilter extends BaseFilter
                 return $choice;
             },
         ));
-        $formBuilder->add('value', 'integer', array('required' => false));
+        $formBuilder->add('value', IntegerType::class, array('required' => false));
     }
 
     /**

--- a/Filter/IntegerFilter.php
+++ b/Filter/IntegerFilter.php
@@ -26,9 +26,6 @@ class IntegerFilter extends BaseFilter
                 '<=' => 'less_than_or_equal',
             ),
             'choices_as_values' => true,
-            'choice_value' => function ($choice) {
-                return $choice;
-            },
         ));
         $formBuilder->add('value', IntegerType::class, array('required' => false));
     }

--- a/Filter/IntegerFilter.php
+++ b/Filter/IntegerFilter.php
@@ -15,13 +15,19 @@ class IntegerFilter extends BaseFilter
      */
     public function buildForm(FormBuilder $formBuilder)
     {
-        $formBuilder->add('type', 'choice', array('choices' => array(
-            'equals'                => '=',
-            'greater_than'          => '>',
-            'greater_than_or_equal' => '>=',
-            'less_than'          => '<',
-            'less_than_or_equal' => '<=',
-        )));
+        $formBuilder->add('type', 'choice', array(
+            'choices' => array(
+                '=' => 'equals',
+                '>' => 'greater_than',
+                '>=' => 'greater_than_or_equal',
+                '<' => 'less_than',
+                '<=' => 'less_than_or_equal',
+            ),
+            'choices_as_values' => true,
+            'choice_value' => function ($choice) {
+                return $choice;
+            },
+        ));
         $formBuilder->add('value', 'integer', array('required' => false));
     }
 

--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -11,6 +11,8 @@
 
 namespace Pablodip\AdminModuleBundle\Filter;
 
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilder;
 use Molino\QueryInterface;
 
@@ -26,7 +28,7 @@ class StringFilter extends BaseFilter
      */
     public function buildForm(FormBuilder $formBuilder)
     {
-        $formBuilder->add('type', 'choice', array(
+        $formBuilder->add('type', ChoiceType::class, array(
             'choices' => array(
                 'Contains' => 'contains',
                 'Not contains' => 'not_contains',
@@ -37,7 +39,7 @@ class StringFilter extends BaseFilter
                 return $choice;
             },
         ));
-        $formBuilder->add('value', 'text', array('required' => false));
+        $formBuilder->add('value', TextType::class, array('required' => false));
     }
 
     /**

--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -26,11 +26,17 @@ class StringFilter extends BaseFilter
      */
     public function buildForm(FormBuilder $formBuilder)
     {
-        $formBuilder->add('type', 'choice', array('choices' => array(
-            'contains'     => 'Contains',
-            'not_contains' => 'Not contains',
-            'exactly'      => 'Exactly',
-        )));
+        $formBuilder->add('type', 'choice', array(
+            'choices' => array(
+                'Contains' => 'contains',
+                'Not contains' => 'not_contains',
+                'Exactly' => 'exactly',
+            ),
+            'choices_as_values' => true,
+            'choice_value' => function ($choice) {
+                return $choice;
+            },
+        ));
         $formBuilder->add('value', 'text', array('required' => false));
     }
 

--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -35,9 +35,6 @@ class StringFilter extends BaseFilter
                 'Exactly' => 'exactly',
             ),
             'choices_as_values' => true,
-            'choice_value' => function ($choice) {
-                return $choice;
-            },
         ));
         $formBuilder->add('value', TextType::class, array('required' => false));
     }

--- a/Module/AdminModule.php
+++ b/Module/AdminModule.php
@@ -20,6 +20,7 @@ use Pablodip\AdminModuleBundle\Field\Guesser\IdFieldGuesser;
 use Pablodip\AdminModuleBundle\Field\Guesser\ValidatorFieldGuesser;
 use Pablodip\AdminModuleBundle\AdminSession;
 use Pablodip\AdminModuleBundle\Action;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 
 /**
  * AdminModule.
@@ -113,7 +114,7 @@ abstract class AdminModule extends Module
 
         $formBuilder = $this->getContainer()
             ->get('form.factory')
-            ->createBuilder('form', $model, $options)
+            ->createBuilder(FormType::class, $model, $options)
         ;
 
         foreach ($fields as $field) {

--- a/Module/AdminModule.php
+++ b/Module/AdminModule.php
@@ -78,7 +78,7 @@ abstract class AdminModule extends Module
      */
     protected function parseConfiguration()
     {
-        if ($this->getContainer()->isScopeActive('request')) {
+        if ($this->getContainer()->get('request_stack')->getCurrentRequest()) {
             $this->adminSession = new AdminSession(
                 $this->getContainer()->get('request'),
                 $this->getContainer()->get('session'),

--- a/TestsProject/src/Pablodip/AdminModuleTestBundle/Module/MandangoArticleAdminModule.php
+++ b/TestsProject/src/Pablodip/AdminModuleTestBundle/Module/MandangoArticleAdminModule.php
@@ -4,6 +4,7 @@ namespace Pablodip\AdminModuleTestBundle\Module;
 
 use Pablodip\AdminModuleBundle\Module\AdminModule;
 use Pablodip\ModuleBundle\Extension\Molino\MandangoMolinoExtension;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 
 class MandangoArticleAdminModule extends AdminModule
 {
@@ -24,7 +25,7 @@ class MandangoArticleAdminModule extends AdminModule
         $modelFields = $this->getOption('model_fields');
         $modelFields->add(array(
             'title',
-            'content' => array('form_type' => 'textarea'),
+            'content' => array('form_type' => TextareaType::class),
             'isActive' => array('label' => 'Is Active?'),
         ));
         $this->getAction('list')->getOption('list_fields')->add(array(

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "^2.7",
+        "symfony/framework-bundle": "^2.8",
         "pablodip/module-bundle": "dev-master"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.2",
+        "symfony/framework-bundle": "^2.7",
         "pablodip/module-bundle": "dev-master"
     },
     "minimum-stability": "dev",

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -27,9 +27,9 @@ You can also pass through settings for these types.  Here's an example:
     $modelFields->add(array(
         'votesPercent' => array(
             'label' => 'votes_percent',
-            'form_type' => 'percent',
+            'form_type' => PercentType::class,
             'template' => 'PablodipAdminModuleBundle::fields/text.html.twig',
-            'form_options' => array('required' => false, 'type' => 'integer')
+            'form_options' => array('required' => false, 'type' => IntegerType::class)
         ),
     ));
     
@@ -50,7 +50,7 @@ Here's an example:
 
         $modelFields->add(array(
             "new_password" => array(
-                "form_type" => "password",
+                "form_type" => PasswordType::class,
                 "label" => "New password",
                 "form_options" => array(
                     'constraints' => new Length(array(


### PR DESCRIPTION
This is a work-in-progress.

The idea behind this branch is to remove usages of things deprecated in more recent Symfony versions, up to and including 2.8.