### PR TITLE
Add missing bracket (1.2 branch)

### DIFF
--- a/Action/ListAction.php
+++ b/Action/ListAction.php
@@ -158,7 +158,7 @@ class ListAction extends RouteAction
         $form = null;
         if ($enabled) {
             $formBuilder = $this->get('form.factory')
-                ->createNamedBuilder($this->getOption('advanced_search_parameter'), 'form', null, array('csrf_protection' => false)
+                ->createNamedBuilder($this->getOption('advanced_search_parameter'), 'form', null, array('csrf_protection' => false))
             ;
             $filters = $this->getAdvancedSearchFilters($fields);
             foreach ($filters as $fieldName => $filter) {


### PR DESCRIPTION
Fixes errors like this when using the 1.2 (Bootstrap 2) version of the project:

```
 Parse error: syntax error, unexpected ';' in vendor/pablodip/admin-module-bundle/Pablodip/AdminModuleBundle/Action/ListAction.php on line 162
```